### PR TITLE
Email validation is rejecting valid email pattern

### DIFF
--- a/widgets/textfieldvalidation/SpryValidationTextField.js
+++ b/widgets/textfieldvalidation/SpryValidationTextField.js
@@ -210,7 +210,7 @@ Spry.Widget.ValidationTextField.ValidationDescriptors = {
 	'email': {
 		characterMasking: /[^\s]/,
 		validation: function(value, options) {
-			var rx = /^[\w\.-]+@[\w\.-]+\.\w+$/i;
+			var rx = /^[\w\.\-\_\+]+@[\w\.\-]+\.\w+$/i;
 			return rx.test(value);
 		}
 	},


### PR DESCRIPTION
I stumbled on this bug while trying to register on a website which uses this framework. I got annoyed that I couldn't use the plus sign in my email and I traced back the problem to a RegExp being too specific in this framework. I made a small modification so that plus sign and underscore are now accepted in email. While the RegExp used is still not RFC compliant, it's at least a step forward in accepting more valid email. 

On a side note, you might want to consider using a RegExp that is too broad (ex.: /^\S+@\S+.\S+$/) instead of too restrictive. It may let invalid email slip through, but it will at least not block valid email.
